### PR TITLE
fix: normaliza CPF removendo máscara antes de salvar

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -102,6 +102,10 @@ class User extends Model
             $value = null;
         }
 
+        if ($property === 'cpf' && $value !== null && $value !== '') {
+            $value = preg_replace('/\D/', '', $value);
+        }
+
         parent::__set($property, $value);
 
         if ($property === 'password' && $this->newRecord() && $value !== null && $value !== '') {


### PR DESCRIPTION
CPF enviado com máscara (529.982.247-25) era salvo no banco com formatação, impedindo o login via CPF sem máscara. O __set agora remove caracteres não numéricos do CPF antes de persistir.