### PR TITLE
ci: adicionar GitHub Actions e limpar comentários nos testes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      APP_ENV: testing
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: zarpa_test
+      DB_USERNAME: root
+      DB_PASSWORD: ''
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: pdo, pdo_mysql, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run unit tests
+        run: ./vendor/bin/phpunit --colors=always

--- a/tests/Unit/Lib/AuthTest.php
+++ b/tests/Unit/Lib/AuthTest.php
@@ -28,7 +28,6 @@ class AuthTest extends TestCase
         return $user;
     }
 
-    // Auth::check()
     public function testCheckReturnsFalseWhenSessionIsEmpty(): void
     {
         $this->assertFalse(Auth::check());
@@ -42,7 +41,6 @@ class AuthTest extends TestCase
         $this->assertTrue(Auth::check());
     }
 
-    // Auth::login()
     public function testLoginStoresUserIdInSession(): void
     {
         $user = $this->makeUser();
@@ -51,7 +49,6 @@ class AuthTest extends TestCase
         $this->assertEquals($user->id, $_SESSION['user']['id']);
     }
 
-    // Auth::user()
     public function testUserReturnsNullWhenNotLoggedIn(): void
     {
         $this->assertNull(Auth::user());
@@ -69,7 +66,6 @@ class AuthTest extends TestCase
         $this->assertEquals($user->email, $loggedUser->email);
     }
 
-    // Auth::logout()
     public function testLogoutMakesCheckReturnFalse(): void
     {
         $user = $this->makeUser();

--- a/tests/Unit/Lib/ValidationsTest.php
+++ b/tests/Unit/Lib/ValidationsTest.php
@@ -25,7 +25,6 @@ class ValidationsTest extends TestCase
         return $obj;
     }
 
-    // notEmpty
     public function testNotEmptyReturnsFalseForNullValue(): void
     {
         $obj = $this->stub(['name' => null]);
@@ -42,7 +41,6 @@ class ValidationsTest extends TestCase
         $this->assertEmpty($obj->errors);
     }
 
-    // email
     public function testEmailReturnsFalseForInvalidEmail(): void
     {
         $obj = $this->stub(['email' => 'nao-e-email']);
@@ -59,7 +57,6 @@ class ValidationsTest extends TestCase
         $this->assertEmpty($obj->errors);
     }
 
-    // minLength
     public function testMinLengthReturnsFalseWhenTooShort(): void
     {
         $obj = $this->stub(['name' => 'AB']);
@@ -76,7 +73,6 @@ class ValidationsTest extends TestCase
         $this->assertEmpty($obj->errors);
     }
 
-    // notFutureDate
     public function testNotFutureDateReturnsFalseForFutureDate(): void
     {
         $obj = $this->stub(['birth_date' => '2099-12-31']);
@@ -101,7 +97,6 @@ class ValidationsTest extends TestCase
         $this->assertEmpty($obj->errors);
     }
 
-    // inclusion
     public function testInclusionReturnsFalseWhenValueNotInList(): void
     {
         $obj = $this->stub(['user_type' => 'superadmin']);
@@ -118,7 +113,6 @@ class ValidationsTest extends TestCase
         $this->assertEmpty($obj->errors);
     }
 
-    // passwordConfirmation
     public function testPasswordConfirmationReturnsFalseWhenMismatch(): void
     {
         $obj = $this->stub(['password' => '123456', 'password_confirmation' => 'diferente']);
@@ -135,7 +129,6 @@ class ValidationsTest extends TestCase
         $this->assertEmpty($obj->errors);
     }
 
-    // cpf
     public function testCpfReturnsTrueForKnownValidCpf(): void
     {
         $obj = $this->stub(['cpf' => '52998224725']);

--- a/tests/Unit/Models/OrderTest.php
+++ b/tests/Unit/Models/OrderTest.php
@@ -41,7 +41,7 @@ class OrderTest extends TestCase
         $user = new User([
             'name'                  => 'Admin Teste',
             'email'                 => 'admin@example.com',
-            'cpf'                   => '11144477735',
+            'cpf'                   => '39053344705',
             'password'              => '123456',
             'password_confirmation' => '123456',
             'user_type'             => User::USER_TYPE_CLIENT,
@@ -193,7 +193,6 @@ class OrderTest extends TestCase
             'distance_km'      => '10.00',
         ]);
 
-        // 10.00 base + 10km * 0.10/km = 11.00
         $this->assertEquals('11.00', $order->calculateShippingFee());
     }
 
@@ -209,7 +208,6 @@ class OrderTest extends TestCase
             'distance_km'      => '20.00',
         ]);
 
-        // 20.00 base + 5.00 fragile + 20km * 0.10 = 27.00
         $this->assertEquals('27.00', $order->calculateShippingFee());
     }
 


### PR DESCRIPTION
- Cria workflow de CI que roda testes unitários com MySQL no GitHub Actions
- Remove comentários de seção redundantes em AuthTest e ValidationsTest
- Corrige CPF duplicado entre makeAdmin e makeDeliverer em OrderTest