### PR TITLE
feat: add delivery photo upload and management for orders

### DIFF
--- a/app/Controllers/OrdersController.php
+++ b/app/Controllers/OrdersController.php
@@ -5,6 +5,7 @@ namespace App\Controllers;
 use App\Models\Notification;
 use App\Models\Order;
 use App\Models\User;
+use App\Services\DeliveryProofUploader;
 use Core\Http\Controllers\Controller;
 use Core\Http\Request;
 use Lib\FlashMessage;
@@ -86,22 +87,46 @@ class OrdersController extends Controller
     {
         $order = $this->findVisibleOrder($request);
         $user = $this->currentUser();
+        $previousStatus = $order->status;
 
         if (!$order->canBeEditedBy($user)) {
             FlashMessage::danger('Voce nao pode alterar este pedido.');
             $this->redirectTo(route('orders.show', ['id' => $order->id]));
         }
 
+        $deliveryPhotoResult = $this->storeDeliveryPhotosFromRequest($request, $order, false);
+        if (!empty($deliveryPhotoResult['errors'])) {
+            FlashMessage::danger(implode(' ', $deliveryPhotoResult['errors']));
+            $clients = $this->clientsForForm();
+            $title = 'Editar pedido #' . $order->id;
+            $this->render('orders/form', compact('title', 'order', 'clients'));
+            return;
+        }
+
         foreach ($this->orderParams($request, $order) as $property => $value) {
             $order->$property = $value;
         }
 
+        if (
+            $user->isDeliverer()
+            && $order->status === Order::STATUS_DELIVERED
+            && empty($order->deliveryPhotos()->get())
+        ) {
+            FlashMessage::danger('Anexe pelo menos uma foto de comprovacao antes de finalizar a entrega.');
+            $clients = $this->clientsForForm();
+            $title = 'Editar pedido #' . $order->id;
+            $this->render('orders/form', compact('title', 'order', 'clients'));
+            return;
+        }
+
         if ($order->save()) {
-            if ($order->status === Order::STATUS_DELIVERED) {
-                $this->finishDeliveredOrder($order);
+            if ($previousStatus !== Order::STATUS_DELIVERED && $order->status === Order::STATUS_DELIVERED) {
+                $this->notifyDeliveredOrder($order);
+                FlashMessage::success('Pedido entregue. O comprovante ficou salvo na galeria.');
+            } else {
+                FlashMessage::success('Pedido atualizado com sucesso.');
             }
 
-            FlashMessage::success('Pedido atualizado com sucesso.');
             $this->redirectTo(route('orders.show', ['id' => $order->id]));
         }
 
@@ -120,6 +145,8 @@ class OrdersController extends Controller
             FlashMessage::danger('Voce nao pode excluir este pedido.');
             $this->redirectTo(route('orders.show', ['id' => $order->id]));
         }
+
+        (new DeliveryProofUploader())->removeAllForOrder($order);
 
         if ($order->destroy()) {
             FlashMessage::success($user->isAdmin() ? 'Pedido excluido com sucesso.' : 'Pedido cancelado com sucesso.');
@@ -147,6 +174,54 @@ class OrdersController extends Controller
             FlashMessage::success('Pedido aceito com sucesso.');
         } else {
             FlashMessage::danger('Nao foi possivel aceitar o pedido.');
+        }
+
+        $this->redirectTo(route('orders.show', ['id' => $order->id]));
+    }
+
+    public function uploadDeliveryPhotos(Request $request): void
+    {
+        $order = $this->findVisibleOrder($request);
+        $user = $this->currentUser();
+
+        if (!$order->canReceiveDeliveryPhotosFrom($user)) {
+            FlashMessage::danger('Voce nao pode anexar comprovantes neste pedido.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        $result = $this->storeDeliveryPhotosFromRequest($request, $order, true);
+
+        if (!empty($result['errors'])) {
+            FlashMessage::danger(implode(' ', $result['errors']));
+        } else {
+            $count = count($result['photos']);
+            FlashMessage::success($count === 1 ? 'Foto anexada com sucesso.' : "{$count} fotos anexadas com sucesso.");
+        }
+
+        $this->redirectTo(route('orders.show', ['id' => $order->id]));
+    }
+
+    public function destroyDeliveryPhoto(Request $request): void
+    {
+        $order = $this->findVisibleOrder($request);
+        $user = $this->currentUser();
+
+        if (!$order->canManageDeliveryPhotosBy($user)) {
+            FlashMessage::danger('Voce nao pode remover este comprovante.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        $photo = $order->deliveryPhotos()->findById((int) $request->getParam('photo_id'));
+
+        if ($photo === null) {
+            FlashMessage::danger('Comprovante nao encontrado.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        if ((new DeliveryProofUploader())->remove($photo)) {
+            FlashMessage::success('Comprovante removido do pedido e do filesystem.');
+        } else {
+            FlashMessage::danger('Nao foi possivel remover o comprovante.');
         }
 
         $this->redirectTo(route('orders.show', ['id' => $order->id]));
@@ -258,16 +333,31 @@ class OrdersController extends Controller
         return strtoupper(substr(bin2hex(random_bytes(4)), 0, 6));
     }
 
-    private function finishDeliveredOrder(Order $order): void
+    /**
+     * @return array{photos: array<\App\Models\OrderDeliveryPhoto>, errors: array<string>}
+     */
+    private function storeDeliveryPhotosFromRequest(Request $request, Order $order, bool $requireFiles): array
+    {
+        $uploader = new DeliveryProofUploader();
+        $fileBag = $request->getFile('delivery_photos', []);
+        $files = $uploader->normalizeFiles($fileBag);
+
+        if (!$requireFiles && empty($files)) {
+            return ['photos' => [], 'errors' => []];
+        }
+
+        if (!empty($files) && !$order->canReceiveDeliveryPhotosFrom($this->currentUser())) {
+            return ['photos' => [], 'errors' => ['Voce nao pode anexar comprovantes neste pedido.']];
+        }
+
+        return $uploader->storeForOrder($order, $fileBag);
+    }
+
+    private function notifyDeliveredOrder(Order $order): void
     {
         Notification::createFor(
             (int) $order->client_id,
             'Seu pedido #' . $order->id . ' foi entregue. Obrigado por usar o Zarpa.'
         );
-
-        $order->destroy();
-
-        FlashMessage::success('Pedido entregue. O cliente foi notificado e o pedido foi removido.');
-        $this->redirectTo(route('orders.index'));
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Core\Database\ActiveRecord\HasMany;
 use Core\Database\ActiveRecord\Model;
 use Core\Database\Database;
 use Lib\Validations;
@@ -181,6 +182,11 @@ class Order extends Model
         return $this->courier_id ? User::findById((int) $this->courier_id) : null;
     }
 
+    public function deliveryPhotos(): HasMany
+    {
+        return $this->hasMany(OrderDeliveryPhoto::class, 'order_id');
+    }
+
     public function statusLabelText(): string
     {
         return self::statusLabel($this->status);
@@ -259,6 +265,18 @@ class Order extends Model
         return $user->isDeliverer()
             && (int) $this->courier_id === (int) $user->id
             && in_array($this->status, [self::STATUS_ACCEPTED, self::STATUS_ON_ROUTE], true);
+    }
+
+    public function canReceiveDeliveryPhotosFrom(User $user): bool
+    {
+        return $user->isDeliverer()
+            && (int) $this->courier_id === (int) $user->id
+            && in_array($this->status, [self::STATUS_ACCEPTED, self::STATUS_ON_ROUTE, self::STATUS_DELIVERED], true);
+    }
+
+    public function canManageDeliveryPhotosBy(User $user): bool
+    {
+        return $user->isAdmin() || $this->canReceiveDeliveryPhotosFrom($user);
     }
 
     /**

--- a/app/Models/OrderDeliveryPhoto.php
+++ b/app/Models/OrderDeliveryPhoto.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use Core\Constants\Constants;
+use Core\Database\ActiveRecord\BelongsTo;
+use Core\Database\ActiveRecord\Model;
+use Lib\Validations;
+
+class OrderDeliveryPhoto extends Model
+{
+    protected static string $table = 'order_delivery_photos';
+    protected static array $columns = [
+        'order_id',
+        'file_name',
+        'original_name',
+        'mime_type',
+        'size_bytes',
+        'created_at'
+    ];
+
+    public const MAX_SIZE_BYTES = 2097152;
+    public const MIME_JPEG = 'image/jpeg';
+    public const MIME_PNG = 'image/png';
+
+    public function __construct($params = [])
+    {
+        parent::__construct($params);
+
+        if ($this->created_at === null) {
+            $this->created_at = date('Y-m-d H:i:s');
+        }
+    }
+
+    public function validates(): void
+    {
+        Validations::notEmpty('order_id', $this);
+        Validations::notEmpty('file_name', $this);
+        Validations::notEmpty('original_name', $this);
+        Validations::notEmpty('mime_type', $this);
+        Validations::notEmpty('size_bytes', $this);
+        Validations::inclusion('mime_type', $this, self::allowedMimeTypes());
+
+        if (!is_numeric($this->size_bytes) || (int) $this->size_bytes <= 0) {
+            $this->addError('size_bytes', 'deve ser maior que zero');
+        } elseif ((int) $this->size_bytes > self::MAX_SIZE_BYTES) {
+            $this->addError('size_bytes', 'deve ter ate 2MB');
+        }
+    }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class, 'order_id');
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function allowedMimeTypes(): array
+    {
+        return [self::MIME_JPEG, self::MIME_PNG];
+    }
+
+    public function publicPath(): string
+    {
+        return '/assets/uploads/delivery-proofs/' . $this->file_name;
+    }
+
+    public function absolutePath(): string
+    {
+        return (string) Constants::rootPath()->join('public' . $this->publicPath());
+    }
+
+    public function formattedSize(): string
+    {
+        return number_format(((int) $this->size_bytes) / 1024, 1, ',', '.') . ' KB';
+    }
+}

--- a/app/Services/DeliveryProofUploader.php
+++ b/app/Services/DeliveryProofUploader.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Models\OrderDeliveryPhoto;
+use Core\Constants\Constants;
+
+class DeliveryProofUploader
+{
+    private const UPLOAD_DIR = 'public/assets/uploads/delivery-proofs';
+
+    /**
+     * @param array<string, mixed> $fileBag
+     * @return array{photos: array<OrderDeliveryPhoto>, errors: array<string>}
+     */
+    public function storeForOrder(Order $order, array $fileBag): array
+    {
+        $files = $this->normalizeFiles($fileBag);
+
+        if (empty($files)) {
+            return ['photos' => [], 'errors' => ['Selecione pelo menos uma foto.']];
+        }
+
+        $errors = $this->validateFiles($files);
+        if (!empty($errors)) {
+            return ['photos' => [], 'errors' => $errors];
+        }
+
+        $storedPhotos = [];
+        $storedPaths = [];
+
+        foreach ($files as $file) {
+            $mimeType = $this->detectMimeType($file['tmp_name']);
+            $fileName = $this->buildFileName($mimeType);
+            $destination = $this->uploadPath($fileName);
+
+            if (!$this->moveUploadedFile($file['tmp_name'], $destination)) {
+                $this->removeStoredPaths($storedPaths);
+                foreach ($storedPhotos as $photo) {
+                    $photo->destroy();
+                }
+
+                return ['photos' => [], 'errors' => ['Nao foi possivel salvar a foto enviada.']];
+            }
+
+            $storedPaths[] = $destination;
+
+            $photo = new OrderDeliveryPhoto([
+                'order_id' => $order->id,
+                'file_name' => $fileName,
+                'original_name' => $this->originalName($file['name']),
+                'mime_type' => $mimeType,
+                'size_bytes' => (int) $file['size'],
+            ]);
+
+            if (!$photo->save()) {
+                $this->removeStoredPaths($storedPaths);
+                foreach ($storedPhotos as $storedPhoto) {
+                    $storedPhoto->destroy();
+                }
+
+                return ['photos' => [], 'errors' => ['Nao foi possivel registrar a foto enviada.']];
+            }
+
+            $storedPhotos[] = $photo;
+        }
+
+        return ['photos' => $storedPhotos, 'errors' => []];
+    }
+
+    public function remove(OrderDeliveryPhoto $photo): bool
+    {
+        $path = $photo->absolutePath();
+
+        if (is_file($path)) {
+            unlink($path);
+        }
+
+        return $photo->destroy();
+    }
+
+    public function removeAllForOrder(Order $order): void
+    {
+        foreach ($order->deliveryPhotos()->get() as $photo) {
+            $this->remove($photo);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $fileBag
+     * @return array<int, array{name: string, type: string, tmp_name: string, error: int, size: int}>
+     */
+    public function normalizeFiles(array $fileBag): array
+    {
+        if (!isset($fileBag['name'])) {
+            return [];
+        }
+
+        if (!is_array($fileBag['name'])) {
+            if (($fileBag['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
+                return [];
+            }
+
+            return [[
+                'name' => (string) ($fileBag['name'] ?? ''),
+                'type' => (string) ($fileBag['type'] ?? ''),
+                'tmp_name' => (string) ($fileBag['tmp_name'] ?? ''),
+                'error' => (int) ($fileBag['error'] ?? UPLOAD_ERR_NO_FILE),
+                'size' => (int) ($fileBag['size'] ?? 0),
+            ]];
+        }
+
+        $files = [];
+
+        foreach ($fileBag['name'] as $index => $name) {
+            $error = (int) ($fileBag['error'][$index] ?? UPLOAD_ERR_NO_FILE);
+            if ($error === UPLOAD_ERR_NO_FILE) {
+                continue;
+            }
+
+            $files[] = [
+                'name' => (string) $name,
+                'type' => (string) ($fileBag['type'][$index] ?? ''),
+                'tmp_name' => (string) ($fileBag['tmp_name'][$index] ?? ''),
+                'error' => $error,
+                'size' => (int) ($fileBag['size'][$index] ?? 0),
+            ];
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param array<int, array{name: string, type: string, tmp_name: string, error: int, size: int}> $files
+     * @return array<string>
+     */
+    private function validateFiles(array $files): array
+    {
+        $errors = [];
+
+        foreach ($files as $file) {
+            $name = $this->originalName($file['name']);
+
+            if ($file['error'] !== UPLOAD_ERR_OK) {
+                $errors[] = "{$name}: falha no envio do arquivo.";
+                continue;
+            }
+
+            if ($file['size'] <= 0) {
+                $errors[] = "{$name}: arquivo vazio.";
+                continue;
+            }
+
+            if ($file['size'] > OrderDeliveryPhoto::MAX_SIZE_BYTES) {
+                $errors[] = "{$name}: tamanho maximo de 2MB.";
+                continue;
+            }
+
+            if (!is_file($file['tmp_name'])) {
+                $errors[] = "{$name}: arquivo temporario nao encontrado.";
+                continue;
+            }
+
+            $mimeType = $this->detectMimeType($file['tmp_name']);
+            if (!in_array($mimeType, OrderDeliveryPhoto::allowedMimeTypes(), true)) {
+                $errors[] = "{$name}: use apenas JPEG ou PNG.";
+                continue;
+            }
+
+            if (@getimagesize($file['tmp_name']) === false) {
+                $errors[] = "{$name}: imagem invalida.";
+            }
+        }
+
+        return $errors;
+    }
+
+    private function detectMimeType(string $path): string
+    {
+        if (class_exists(\finfo::class)) {
+            $finfo = new \finfo(FILEINFO_MIME_TYPE);
+            return (string) $finfo->file($path);
+        }
+
+        $imageInfo = @getimagesize($path);
+        return is_array($imageInfo) ? (string) ($imageInfo['mime'] ?? '') : '';
+    }
+
+    private function buildFileName(string $mimeType): string
+    {
+        $extension = $mimeType === OrderDeliveryPhoto::MIME_PNG ? 'png' : 'jpg';
+        return bin2hex(random_bytes(16)) . '.' . $extension;
+    }
+
+    private function uploadPath(string $fileName): string
+    {
+        $directory = (string) Constants::rootPath()->join(self::UPLOAD_DIR);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        return $directory . DIRECTORY_SEPARATOR . $fileName;
+    }
+
+    private function originalName(string $name): string
+    {
+        return substr(basename(str_replace('\\', '/', $name)), 0, 255);
+    }
+
+    private function moveUploadedFile(string $source, string $destination): bool
+    {
+        if (is_uploaded_file($source)) {
+            return move_uploaded_file($source, $destination);
+        }
+
+        if (PHP_SAPI === 'cli') {
+            if (!copy($source, $destination)) {
+                return false;
+            }
+
+            unlink($source);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string> $paths
+     */
+    private function removeStoredPaths(array $paths): void
+    {
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+}

--- a/app/views/orders/form.phtml
+++ b/app/views/orders/form.phtml
@@ -22,7 +22,7 @@ $statusOptions = $isAdmin
         </a>
     </div>
 
-    <form action="<?= $formAction ?>" method="POST" data-validate-form data-order-pricing novalidate>
+    <form action="<?= $formAction ?>" method="POST" enctype="multipart/form-data" data-validate-form data-order-pricing novalidate>
         <?php if (!$isNew) : ?>
             <input type="hidden" name="_method" value="PUT">
         <?php endif; ?>
@@ -166,6 +166,11 @@ $statusOptions = $isAdmin
                 <label class="form-label" for="order-confirmation-code">Codigo de confirmacao</label>
                 <input id="order-confirmation-code" type="text" name="order[confirmation_code]" class="form-control"
                        value="<?= htmlspecialchars($order->confirmation_code ?? '') ?>" maxlength="20">
+            </div>
+            <?php elseif ($isDeliverer && $order->canReceiveDeliveryPhotosFrom($user)) : ?>
+            <div class="col-12">
+                <label class="form-label" for="delivery-photos">Fotos do comprovante</label>
+                <input id="delivery-photos" class="form-control" type="file" name="delivery_photos[]" accept="image/jpeg,image/png" multiple>
             </div>
             <?php endif; ?>
         </div>

--- a/app/views/orders/show.phtml
+++ b/app/views/orders/show.phtml
@@ -2,6 +2,9 @@
 $user = $this->current_user;
 $client = $order->client();
 $courier = $order->courier();
+$deliveryPhotos = $order->deliveryPhotos()->get();
+$canUploadDeliveryPhotos = $order->canReceiveDeliveryPhotosFrom($user);
+$canManageDeliveryPhotos = $order->canManageDeliveryPhotosBy($user);
 ?>
 
 <section class="delivery-hero mb-3">
@@ -67,6 +70,59 @@ $courier = $order->courier();
             <div class="fw-semibold"><?= $order->created_at ? date('d/m/Y H:i', strtotime($order->created_at)) : '-' ?></div>
         </div>
     </div>
+</section>
+
+<section class="admin-panel delivery-proof-panel mb-3">
+    <div class="section-toolbar mb-3">
+        <div>
+            <div class="profile-label">Galeria</div>
+            <h2 class="h5 mb-0">Comprovantes de entrega</h2>
+        </div>
+        <span class="badge text-bg-light"><?= count($deliveryPhotos) ?> foto<?= count($deliveryPhotos) === 1 ? '' : 's' ?></span>
+    </div>
+
+    <?php if ($canUploadDeliveryPhotos) : ?>
+    <form class="proof-upload-form mb-3" action="<?= route('order_delivery_photos.create', ['id' => $order->id]) ?>" method="POST" enctype="multipart/form-data">
+        <div class="proof-upload-field">
+            <label class="form-label" for="delivery-photos">Fotos do comprovante</label>
+            <input id="delivery-photos" class="form-control" type="file" name="delivery_photos[]" accept="image/jpeg,image/png" multiple required>
+        </div>
+        <button class="btn btn-success" type="submit">
+            <i class="bi bi-cloud-arrow-up"></i> Anexar
+        </button>
+    </form>
+    <?php endif; ?>
+
+    <?php if (empty($deliveryPhotos)) : ?>
+        <div class="empty-state proof-empty">
+            <i class="bi bi-images fs-3 text-muted"></i>
+            <p class="mb-0 text-muted">Nenhum comprovante anexado.</p>
+        </div>
+    <?php else : ?>
+        <div class="delivery-proof-grid">
+            <?php foreach ($deliveryPhotos as $photo) : ?>
+            <figure class="delivery-proof-card">
+                <a href="<?= htmlspecialchars($photo->publicPath()) ?>" target="_blank" rel="noopener">
+                    <img src="<?= htmlspecialchars($photo->publicPath()) ?>" alt="<?= htmlspecialchars($photo->original_name) ?>">
+                </a>
+                <figcaption>
+                    <div>
+                        <strong><?= htmlspecialchars($photo->original_name) ?></strong>
+                        <span><?= htmlspecialchars($photo->formattedSize()) ?></span>
+                    </div>
+                    <?php if ($canManageDeliveryPhotos) : ?>
+                    <form action="<?= route('order_delivery_photos.destroy', ['id' => $order->id, 'photo_id' => $photo->id]) ?>" method="POST" onsubmit="return confirm('Remover este comprovante?')">
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button class="btn btn-sm btn-outline-danger" type="submit" title="Remover comprovante" aria-label="Remover comprovante">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </form>
+                    <?php endif; ?>
+                </figcaption>
+            </figure>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
 </section>
 
 <section class="action-bar">

--- a/config/routes.php
+++ b/config/routes.php
@@ -26,6 +26,8 @@ Route::middleware('auth')->group(function () {
     Route::delete('/orders/{id}', [OrdersController::class, 'destroy'])->name('orders.destroy');
     Route::post('/orders/{id}/accept', [OrdersController::class, 'accept'])->name('orders.accept');
     Route::post('/orders/{id}/refuse', [OrdersController::class, 'refuse'])->name('orders.refuse');
+    Route::post('/orders/{id}/delivery-photos', [OrdersController::class, 'uploadDeliveryPhotos'])->name('order_delivery_photos.create');
+    Route::delete('/orders/{id}/delivery-photos/{photo_id}', [OrdersController::class, 'destroyDeliveryPhoto'])->name('order_delivery_photos.destroy');
 });
 
 Route::middleware('admin')->group(function () {

--- a/core/Database/ActiveRecord/Model.php
+++ b/core/Database/ActiveRecord/Model.php
@@ -230,7 +230,8 @@ abstract class Model
         return ($stmt->rowCount() != 0);
     }
 
-    public static function findById(int $id): static|null
+    public static function findById(int $id): static|null 
+    // SELECT * FROM {table} WHERE id = :id LIMIT 1` → retorna uma instância ou `null`.
     {
         $pdo = Database::getDatabaseConn();
 

--- a/core/Http/Request.php
+++ b/core/Http/Request.php
@@ -10,6 +10,9 @@ class Request
     /** @var mixed[] */
     private array $params;
 
+    /** @var mixed[] */
+    private array $files;
+
     /** @var array<string, string> */
     private array $headers;
 
@@ -18,6 +21,7 @@ class Request
         $this->method = $_REQUEST['_method'] ?? $_SERVER['REQUEST_METHOD'];
         $this->uri = $_SERVER['REQUEST_URI'];
         $this->params = $_REQUEST;
+        $this->files = $_FILES;
         $this->headers = function_exists('getallheaders') ? getallheaders() : [];
     }
 
@@ -57,5 +61,10 @@ class Request
     public function getParam(string $key, mixed $default = null): mixed
     {
         return $this->params[$key] ?? $default;
+    }
+
+    public function getFile(string $key, mixed $default = []): mixed
+    {
+        return $this->files[$key] ?? $default;
     }
 }

--- a/database/Populate/populate.php
+++ b/database/Populate/populate.php
@@ -12,6 +12,9 @@ $senha = password_hash('password123', PASSWORD_DEFAULT);
 $adminSenha = password_hash('admin123', PASSWORD_DEFAULT);
 
 if ($pdo->query("SHOW TABLES LIKE 'orders'")->fetchColumn()) {
+    if ($pdo->query("SHOW TABLES LIKE 'order_delivery_photos'")->fetchColumn()) {
+        $pdo->exec("DELETE FROM order_delivery_photos");
+    }
     $pdo->exec("DELETE FROM orders");
 }
 if ($pdo->query("SHOW TABLES LIKE 'notifications'")->fetchColumn()) {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,5 +1,6 @@
 SET foreign_key_checks = 0;
 
+DROP TABLE IF EXISTS order_delivery_photos;
 DROP TABLE IF EXISTS orders;
 DROP TABLE IF EXISTS notifications;
 DROP TABLE IF EXISTS users;
@@ -34,6 +35,17 @@ CREATE TABLE orders (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_orders_client FOREIGN KEY (client_id) REFERENCES users(id) ON DELETE CASCADE,
     CONSTRAINT fk_orders_courier FOREIGN KEY (courier_id) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE order_delivery_photos (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT NOT NULL,
+    file_name VARCHAR(120) NOT NULL,
+    original_name VARCHAR(255) NOT NULL,
+    mime_type VARCHAR(30) NOT NULL,
+    size_bytes INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_order_delivery_photos_order FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE notifications (

--- a/public/assets/css/application.css
+++ b/public/assets/css/application.css
@@ -512,6 +512,66 @@ body.app-screen {
   opacity: 0.55;
 }
 
+.proof-upload-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: end;
+  padding-top: 14px;
+  border-top: 1px solid rgba(22, 24, 28, 0.08);
+}
+
+.delivery-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.delivery-proof-card {
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid rgba(22, 24, 28, 0.08);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.delivery-proof-card a {
+  display: block;
+  aspect-ratio: 4 / 3;
+  background: rgba(22, 24, 28, 0.04);
+}
+
+.delivery-proof-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.delivery-proof-card figcaption {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 10px;
+}
+
+.delivery-proof-card strong,
+.delivery-proof-card span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delivery-proof-card strong {
+  font-size: 0.86rem;
+}
+
+.delivery-proof-card span {
+  color: var(--zarpa-muted);
+  font-size: 0.76rem;
+}
+
 .btn {
   border-radius: 8px;
   font-weight: 700;
@@ -564,7 +624,8 @@ body.app-screen {
   }
 
   .form-grid,
-  .order-meta-grid {
+  .order-meta-grid,
+  .proof-upload-form {
     grid-template-columns: 1fr;
   }
 

--- a/tests/Acceptance/Orders/DeliveryPhotosCest.php
+++ b/tests/Acceptance/Orders/DeliveryPhotosCest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Acceptance\Orders;
+
+use App\Models\Order;
+use App\Models\User;
+use Core\Constants\Constants;
+use Tests\Acceptance\BaseAcceptanceCest;
+use Tests\Support\AcceptanceTester;
+
+class DeliveryPhotosCest extends BaseAcceptanceCest
+{
+    public function _after(AcceptanceTester $page): void
+    {
+        $this->cleanupUploadDirectory();
+        $this->removeProofFixture();
+        parent::_after($page);
+    }
+
+    private function makeClient(): User
+    {
+        $user = new User([
+            'name'                  => 'Cliente Teste',
+            'email'                 => 'cliente@example.com',
+            'cpf'                   => '52998224725',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_CLIENT,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeDeliverer(): User
+    {
+        $user = new User([
+            'name'                  => 'Entregador Teste',
+            'email'                 => 'entregador@example.com',
+            'cpf'                   => '11144477735',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_DELIVERER,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeAcceptedOrder(User $client, User $deliverer): Order
+    {
+        $order = new Order([
+            'client_id'         => $client->id,
+            'courier_id'       => $deliverer->id,
+            'pickup_address'    => 'Rua de Coleta, 123',
+            'delivery_address'  => 'Rua de Entrega, 456',
+            'package_size'      => Order::PACKAGE_SMALL,
+            'payment_method'    => Order::PAYMENT_PIX,
+            'distance_km'       => '1.00',
+            'status'            => Order::STATUS_ACCEPTED,
+            'confirmation_code' => 'ABC123',
+        ]);
+        $order->save();
+        return $order;
+    }
+
+    // 1.1, 1.2, 1.3 - Upload, visualizacao e remocao de imagem/arquivo
+    public function delivererUploadsViewsAndRemovesDeliveryPhoto(AcceptanceTester $page): void
+    {
+        $client = $this->makeClient();
+        $deliverer = $this->makeDeliverer();
+        $order = $this->makeAcceptedOrder($client, $deliverer);
+        $this->ensureProofFixture();
+
+        $page->login($deliverer->email, '123456');
+        $page->amOnPage('/orders/' . $order->id);
+        $page->attachFile('#delivery-photos', 'proof.png');
+        $page->click('Anexar');
+
+        $page->see('Foto anexada com sucesso.');
+        $page->see('proof.png');
+
+        $page->click('.delivery-proof-card .btn-outline-danger');
+        $page->acceptPopup();
+
+        $page->see('Comprovante removido do pedido e do filesystem.');
+        $page->see('Nenhum comprovante anexado.');
+    }
+
+    private function ensureProofFixture(): void
+    {
+        $png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z8BQDwAFgwJ/lOKZVwAAAABJRU5ErkJggg==';
+        file_put_contents($this->proofFixturePath(), base64_decode($png));
+    }
+
+    private function removeProofFixture(): void
+    {
+        $path = $this->proofFixturePath();
+
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+
+    private function proofFixturePath(): string
+    {
+        return (string) Constants::rootPath()->join('tests/Support/Data/proof.png');
+    }
+
+    private function cleanupUploadDirectory(): void
+    {
+        $directory = (string) Constants::rootPath()->join('public/assets/uploads/delivery-proofs');
+
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . DIRECTORY_SEPARATOR . '*') ?: [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+}

--- a/tests/Support/AcceptanceTester.php
+++ b/tests/Support/AcceptanceTester.php
@@ -7,11 +7,13 @@ namespace Tests\Support;
 /**
  * @method void amOnPage(string $url)
  * @method void fillField(string $field, string $value)
+ * @method void attachFile(string $field, string $filename)
  * @method void click(string $button)
  * @method void see(string $text, string $selector = null)
  * @method void dontSee(string $text, string $selector = null)
  * @method void seeInCurrentUrl(string $url)
  * @method void dontSeeInCurrentUrl(string $url)
+ * @method void acceptPopup()
  * @method void login(string $identifier, string $password)
  * @method void logout()
  *

--- a/tests/Unit/Models/OrderDeliveryPhotoTest.php
+++ b/tests/Unit/Models/OrderDeliveryPhotoTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Order;
+use App\Models\OrderDeliveryPhoto;
+use App\Models\User;
+use Tests\TestCase;
+
+class OrderDeliveryPhotoTest extends TestCase
+{
+    private function makeClient(): User
+    {
+        $user = new User([
+            'name'                  => 'Cliente Teste',
+            'email'                 => 'cliente@example.com',
+            'cpf'                   => '52998224725',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_CLIENT,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeOrder(): Order
+    {
+        $order = new Order([
+            'client_id' => $this->makeClient()->id,
+            'pickup_address' => 'Rua de Coleta, 123',
+            'delivery_address' => 'Rua de Entrega, 456',
+            'distance_km' => '1.00',
+        ]);
+        $order->save();
+        return $order;
+    }
+
+    public function testSaveFailsWithoutRequiredFields(): void
+    {
+        $photo = new OrderDeliveryPhoto();
+
+        $this->assertFalse($photo->save());
+        $this->assertNotEmpty($photo->errors('order_id'));
+        $this->assertNotEmpty($photo->errors('file_name'));
+        $this->assertNotEmpty($photo->errors('mime_type'));
+    }
+
+    public function testSaveFailsWithInvalidMimeType(): void
+    {
+        $order = $this->makeOrder();
+        $photo = new OrderDeliveryPhoto([
+            'order_id' => $order->id,
+            'file_name' => 'comprovante.txt',
+            'original_name' => 'comprovante.txt',
+            'mime_type' => 'text/plain',
+            'size_bytes' => 100,
+        ]);
+
+        $this->assertFalse($photo->save());
+        $this->assertNotEmpty($photo->errors('mime_type'));
+    }
+
+    public function testOrderHasManyDeliveryPhotos(): void
+    {
+        $order = $this->makeOrder();
+        $photo = new OrderDeliveryPhoto([
+            'order_id' => $order->id,
+            'file_name' => 'comprovante.png',
+            'original_name' => 'comprovante.png',
+            'mime_type' => OrderDeliveryPhoto::MIME_PNG,
+            'size_bytes' => 100,
+        ]);
+        $photo->save();
+
+        $photos = $order->deliveryPhotos()->get();
+
+        $this->assertCount(1, $photos);
+        $this->assertEquals($photo->id, $photos[0]->id);
+    }
+
+    public function testPhotoBelongsToOrder(): void
+    {
+        $order = $this->makeOrder();
+        $photo = new OrderDeliveryPhoto([
+            'order_id' => $order->id,
+            'file_name' => 'comprovante.png',
+            'original_name' => 'comprovante.png',
+            'mime_type' => OrderDeliveryPhoto::MIME_PNG,
+            'size_bytes' => 100,
+        ]);
+        $photo->save();
+
+        $this->assertEquals($order->id, $photo->order->id);
+    }
+}

--- a/tests/Unit/Models/OrderTest.php
+++ b/tests/Unit/Models/OrderTest.php
@@ -394,6 +394,57 @@ class OrderTest extends TestCase
         $this->assertFalse($order->canBeRefusedBy($deliverer));
     }
 
+    // 3.1 - canReceiveDeliveryPhotosFrom()
+
+    public function testAssignedDelivererCanUploadDeliveryPhotos(): void
+    {
+        $client = $this->makeClient();
+        $deliverer = $this->makeDeliverer();
+        $order = $this->makeOrder($client, [
+            'status'     => Order::STATUS_ON_ROUTE,
+            'courier_id' => $deliverer->id,
+        ]);
+
+        $this->assertTrue($order->canReceiveDeliveryPhotosFrom($deliverer));
+    }
+
+    public function testUnassignedDelivererCannotUploadDeliveryPhotos(): void
+    {
+        $client = $this->makeClient();
+        $deliverer = $this->makeDeliverer();
+        $otherDeliverer = $this->makeDeliverer([
+            'email' => 'outro.entregador@example.com',
+            'cpf'   => '39053344705',
+        ]);
+        $order = $this->makeOrder($client, [
+            'status'     => Order::STATUS_ON_ROUTE,
+            'courier_id' => $deliverer->id,
+        ]);
+
+        $this->assertFalse($order->canReceiveDeliveryPhotosFrom($otherDeliverer));
+    }
+
+    public function testClientCannotUploadDeliveryPhotos(): void
+    {
+        $client = $this->makeClient();
+        $deliverer = $this->makeDeliverer();
+        $order = $this->makeOrder($client, [
+            'status'     => Order::STATUS_ON_ROUTE,
+            'courier_id' => $deliverer->id,
+        ]);
+
+        $this->assertFalse($order->canReceiveDeliveryPhotosFrom($client));
+    }
+
+    public function testAdminCanManageDeliveryPhotos(): void
+    {
+        $admin = $this->makeAdmin();
+        $client = $this->makeClient();
+        $order = $this->makeOrder($client);
+
+        $this->assertTrue($order->canManageDeliveryPhotosBy($admin));
+    }
+
     // 3.1 - isFragile()
 
     public function testIsFragileReturnsTrueWhenSet(): void
@@ -459,5 +510,22 @@ class OrderTest extends TestCase
         $ids = array_map(fn($o) => $o->id, $visible);
         $this->assertContains($pending->id, $ids);
         $this->assertContains($assigned->id, $ids);
+    }
+
+    public function testVisibleForDelivererIncludesTheirDeliveredOrders(): void
+    {
+        $client = $this->makeClient();
+        $deliverer = $this->makeDeliverer();
+
+        $delivered = $this->makeOrder($client, [
+            'status'            => Order::STATUS_DELIVERED,
+            'courier_id'        => $deliverer->id,
+            'confirmation_code' => 'DLV001',
+        ]);
+
+        $visible = Order::visibleFor($deliverer);
+
+        $ids = array_map(fn($o) => $o->id, $visible);
+        $this->assertContains($delivered->id, $ids);
     }
 }

--- a/tests/Unit/Services/DeliveryProofUploaderTest.php
+++ b/tests/Unit/Services/DeliveryProofUploaderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Order;
+use App\Models\OrderDeliveryPhoto;
+use App\Models\User;
+use App\Services\DeliveryProofUploader;
+use Core\Constants\Constants;
+use Tests\TestCase;
+
+class DeliveryProofUploaderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->cleanupUploadDirectory();
+        parent::tearDown();
+    }
+
+    private function makeClient(): User
+    {
+        $user = new User([
+            'name'                  => 'Cliente Teste',
+            'email'                 => 'cliente@example.com',
+            'cpf'                   => '52998224725',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_CLIENT,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeOrder(): Order
+    {
+        $order = new Order([
+            'client_id' => $this->makeClient()->id,
+            'pickup_address' => 'Rua de Coleta, 123',
+            'delivery_address' => 'Rua de Entrega, 456',
+            'distance_km' => '1.00',
+        ]);
+        $order->save();
+        return $order;
+    }
+
+    public function testStoresUploadedImageAndCreatesRecord(): void
+    {
+        $order = $this->makeOrder();
+        $tmp = $this->makeTempPng();
+        $uploader = new DeliveryProofUploader();
+
+        $result = $uploader->storeForOrder($order, $this->fileBag($tmp, 'entrega.png'));
+
+        $this->assertEmpty($result['errors']);
+        $this->assertCount(1, $result['photos']);
+        $photo = $result['photos'][0];
+
+        $this->assertSame($order->id, (int) $photo->order_id);
+        $this->assertSame(OrderDeliveryPhoto::MIME_PNG, $photo->mime_type);
+        $this->assertFileExists($photo->absolutePath());
+        $this->assertCount(1, $order->deliveryPhotos()->get());
+    }
+
+    public function testRejectsInvalidImagePayload(): void
+    {
+        $order = $this->makeOrder();
+        $tmp = tempnam(sys_get_temp_dir(), 'proof_');
+        file_put_contents($tmp, '<?php echo "malicioso";');
+        $uploader = new DeliveryProofUploader();
+
+        $result = $uploader->storeForOrder($order, $this->fileBag($tmp, 'entrega.png'));
+
+        $this->assertNotEmpty($result['errors']);
+        $this->assertCount(0, $order->deliveryPhotos()->get());
+
+        if (is_file($tmp)) {
+            unlink($tmp);
+        }
+    }
+
+    public function testRejectsFilesLargerThanTwoMegabytes(): void
+    {
+        $order = $this->makeOrder();
+        $tmp = $this->makeTempPng();
+        $uploader = new DeliveryProofUploader();
+
+        $result = $uploader->storeForOrder(
+            $order,
+            $this->fileBag($tmp, 'entrega.png', OrderDeliveryPhoto::MAX_SIZE_BYTES + 1)
+        );
+
+        $this->assertNotEmpty($result['errors']);
+        $this->assertCount(0, $order->deliveryPhotos()->get());
+
+        if (is_file($tmp)) {
+            unlink($tmp);
+        }
+    }
+
+    public function testRemovesImageFromFilesystemAndDatabase(): void
+    {
+        $order = $this->makeOrder();
+        $tmp = $this->makeTempPng();
+        $uploader = new DeliveryProofUploader();
+        $result = $uploader->storeForOrder($order, $this->fileBag($tmp, 'entrega.png'));
+        $photo = $result['photos'][0];
+        $path = $photo->absolutePath();
+
+        $this->assertTrue($uploader->remove($photo));
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertNull(OrderDeliveryPhoto::findById($photo->id));
+    }
+
+    /**
+     * @return array{name: array<int, string>, type: array<int, string>, tmp_name: array<int, string>, error: array<int, int>, size: array<int, int>}
+     */
+    private function fileBag(string $path, string $name, ?int $size = null): array
+    {
+        return [
+            'name' => [$name],
+            'type' => [OrderDeliveryPhoto::MIME_PNG],
+            'tmp_name' => [$path],
+            'error' => [UPLOAD_ERR_OK],
+            'size' => [$size ?? filesize($path)],
+        ];
+    }
+
+    private function makeTempPng(): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'proof_');
+        $png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z8BQDwAFgwJ/lOKZVwAAAABJRU5ErkJggg==';
+        file_put_contents($tmp, base64_decode($png));
+
+        return $tmp;
+    }
+
+    private function cleanupUploadDirectory(): void
+    {
+        $directory = (string) Constants::rootPath()->join('public/assets/uploads/delivery-proofs');
+
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . DIRECTORY_SEPARATOR . '*') ?: [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Implemented functionality for deliverers to upload delivery proof photos for orders.
- Added methods in OrdersController for uploading and deleting delivery photos.
- Created OrderDeliveryPhoto model to handle delivery photo data.
- Introduced DeliveryProofUploader service for managing file uploads and validations.
- Updated Order model to include relationships and permissions for delivery photos.
- Enhanced order forms and views to support photo uploads and display.
- Added tests for delivery photo upload and management features.