### PR TITLE
feat: adicionar relacao N:N entre pedidos e etiquetas

### DIFF
--- a/app/Controllers/OrdersController.php
+++ b/app/Controllers/OrdersController.php
@@ -4,6 +4,7 @@ namespace App\Controllers;
 
 use App\Models\Notification;
 use App\Models\Order;
+use App\Models\Tag;
 use App\Models\User;
 use Core\Http\Controllers\Controller;
 use Core\Http\Request;
@@ -172,6 +173,50 @@ class OrdersController extends Controller
         }
 
         $this->redirectTo(route('orders.index'));
+    }
+
+    public function attachTag(Request $request): void
+    {
+        $order = $this->findVisibleOrder($request);
+        $user = $this->currentUser();
+
+        if (!$order->canManageTagsBy($user)) {
+            FlashMessage::danger('Voce nao pode gerenciar as etiquetas deste pedido.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        $tag = Tag::findById((int) $request->getParam('tag_id'));
+
+        if ($tag === null) {
+            FlashMessage::danger('Etiqueta nao encontrada.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        if ($order->tags()->exists((int) $tag->id)) {
+            FlashMessage::danger('Esta etiqueta ja esta vinculada ao pedido.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        $order->tags()->attach((int) $tag->id);
+
+        FlashMessage::success('Etiqueta vinculada ao pedido.');
+        $this->redirectTo(route('orders.show', ['id' => $order->id]));
+    }
+
+    public function detachTag(Request $request): void
+    {
+        $order = $this->findVisibleOrder($request);
+        $user = $this->currentUser();
+
+        if (!$order->canManageTagsBy($user)) {
+            FlashMessage::danger('Voce nao pode gerenciar as etiquetas deste pedido.');
+            $this->redirectTo(route('orders.show', ['id' => $order->id]));
+        }
+
+        $order->tags()->detach((int) $request->getParam('tag_id'));
+
+        FlashMessage::success('Etiqueta removida do pedido.');
+        $this->redirectTo(route('orders.show', ['id' => $order->id]));
     }
 
     private function findVisibleOrder(Request $request): Order

--- a/app/Controllers/TagsController.php
+++ b/app/Controllers/TagsController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Models\Tag;
+use Core\Http\Controllers\Controller;
+use Core\Http\Request;
+use Lib\FlashMessage;
+
+class TagsController extends Controller
+{
+    public function index(): void
+    {
+        $title = 'Etiquetas';
+        $tags = Tag::orderedByName();
+
+        $this->render('tags/index', compact('title', 'tags'));
+    }
+
+    public function create(Request $request): void
+    {
+        if (!$this->currentUser()->isAdmin()) {
+            FlashMessage::danger('Apenas administradores podem gerenciar etiquetas.');
+            $this->redirectTo(route('tags.index'));
+        }
+
+        $params = $request->getParam('tag', []);
+        $tag = new Tag([
+            'name' => trim($params['name'] ?? ''),
+            'color' => $params['color'] ?? Tag::COLOR_SECONDARY
+        ]);
+
+        if ($tag->save()) {
+            FlashMessage::success('Etiqueta criada com sucesso.');
+        } else {
+            FlashMessage::danger('Verifique os dados da etiqueta.');
+        }
+
+        $this->redirectTo(route('tags.index'));
+    }
+
+    public function destroy(Request $request): void
+    {
+        if (!$this->currentUser()->isAdmin()) {
+            FlashMessage::danger('Apenas administradores podem gerenciar etiquetas.');
+            $this->redirectTo(route('tags.index'));
+        }
+
+        $tag = Tag::findById((int) $request->getParam('id'));
+
+        if ($tag === null) {
+            FlashMessage::danger('Etiqueta nao encontrada.');
+            $this->redirectTo(route('tags.index'));
+        }
+
+        if ($tag->destroy()) {
+            FlashMessage::success('Etiqueta removida. Os vinculos com os pedidos tambem foram apagados.');
+        } else {
+            FlashMessage::danger('Nao foi possivel remover a etiqueta.');
+        }
+
+        $this->redirectTo(route('tags.index'));
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Core\Database\ActiveRecord\BelongsToMany;
 use Core\Database\ActiveRecord\Model;
 use Core\Database\Database;
 use Lib\Validations;
@@ -181,6 +182,19 @@ class Order extends Model
         return $this->courier_id ? User::findById((int) $this->courier_id) : null;
     }
 
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'order_tags', 'order_id', 'tag_id');
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function tagIds(): array
+    {
+        return array_map(fn(Tag $tag) => (int) $tag->id, $this->tags()->get());
+    }
+
     public function statusLabelText(): string
     {
         return self::statusLabel($this->status);
@@ -259,6 +273,12 @@ class Order extends Model
         return $user->isDeliverer()
             && (int) $this->courier_id === (int) $user->id
             && in_array($this->status, [self::STATUS_ACCEPTED, self::STATUS_ON_ROUTE], true);
+    }
+
+    public function canManageTagsBy(User $user): bool
+    {
+        return $user->isAdmin()
+            || (int) $this->client_id === (int) $user->id;
     }
 
     /**

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Core\Database\ActiveRecord\BelongsToMany;
+use Core\Database\ActiveRecord\HasMany;
 use Core\Database\ActiveRecord\Model;
 use Core\Database\Database;
 use Lib\Validations;
@@ -187,6 +188,11 @@ class Order extends Model
         return $this->belongsToMany(Tag::class, 'order_tags', 'order_id', 'tag_id');
     }
 
+    public function deliveryPhotos(): HasMany
+    {
+        return $this->hasMany(OrderDeliveryPhoto::class, 'order_id');
+    }
+
     /**
      * @return array<int>
      */
@@ -279,6 +285,19 @@ class Order extends Model
     {
         return $user->isAdmin()
             || (int) $this->client_id === (int) $user->id;
+    }
+
+    public function canReceiveDeliveryPhotosFrom(User $user): bool
+    {
+        return $user->isDeliverer()
+            && (int) $this->courier_id === (int) $user->id
+            && $this->status === self::STATUS_ON_ROUTE;
+    }
+
+    public function canManageDeliveryPhotosBy(User $user): bool
+    {
+        return $user->isAdmin()
+            || ($user->isDeliverer() && (int) $this->courier_id === (int) $user->id);
     }
 
     /**

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Core\Database\ActiveRecord\BelongsToMany;
+use Core\Database\ActiveRecord\Model;
+use Lib\Validations;
+
+class Tag extends Model
+{
+    protected static string $table = 'tags';
+    protected static array $columns = ['name', 'color'];
+
+    public const COLOR_SECONDARY = 'secondary';
+    public const COLOR_PRIMARY = 'primary';
+    public const COLOR_SUCCESS = 'success';
+    public const COLOR_DANGER = 'danger';
+    public const COLOR_WARNING = 'warning';
+    public const COLOR_INFO = 'info';
+    public const COLOR_DARK = 'dark';
+
+    public function __construct($params = [])
+    {
+        parent::__construct($params);
+
+        if ($this->color === null) {
+            $this->color = self::COLOR_SECONDARY;
+        }
+    }
+
+    public function validates(): void
+    {
+        Validations::notEmpty('name', $this);
+        Validations::minLength('name', $this, 2);
+        Validations::uniqueness('name', $this);
+        Validations::inclusion('color', $this, self::colors());
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function colors(): array
+    {
+        return [
+            self::COLOR_SECONDARY,
+            self::COLOR_PRIMARY,
+            self::COLOR_SUCCESS,
+            self::COLOR_DANGER,
+            self::COLOR_WARNING,
+            self::COLOR_INFO,
+            self::COLOR_DARK
+        ];
+    }
+
+    public function orders(): BelongsToMany
+    {
+        return $this->belongsToMany(Order::class, 'order_tags', 'tag_id', 'order_id');
+    }
+
+    public function badgeClass(): string
+    {
+        return 'text-bg-' . $this->color;
+    }
+
+    /**
+     * @return array<Tag>
+     */
+    public static function orderedByName(): array
+    {
+        $tags = self::all();
+        usort($tags, fn(Tag $a, Tag $b) => strcasecmp($a->name, $b->name));
+
+        return $tags;
+    }
+}

--- a/app/views/layouts/application.phtml
+++ b/app/views/layouts/application.phtml
@@ -29,6 +29,7 @@
             <ul class="dropdown-menu dropdown-menu-end">
                 <li><span class="dropdown-item-text text-muted small"><?= htmlspecialchars($this->current_user->email) ?></span></li>
                 <li><a class="dropdown-item" href="<?= route('orders.index') ?>"><i class="bi bi-receipt"></i> Pedidos</a></li>
+                <li><a class="dropdown-item" href="<?= route('tags.index') ?>"><i class="bi bi-tags"></i> Etiquetas</a></li>
                 <?php if ($this->current_user->isAdmin()) : ?>
                 <li><a class="dropdown-item" href="<?= route('admin.dashboard') ?>"><i class="bi bi-speedometer2"></i> Admin</a></li>
                 <?php endif; ?>
@@ -50,6 +51,10 @@
         <a href="<?= route('orders.index') ?>">
             <i class="bi bi-receipt"></i>
             <span>Pedidos</span>
+        </a>
+        <a href="<?= route('tags.index') ?>">
+            <i class="bi bi-tags"></i>
+            <span>Etiquetas</span>
         </a>
         <?php if (!$this->current_user->isDeliverer() || $this->current_user->isAdmin()) : ?>
         <a href="<?= route('orders.new') ?>">

--- a/app/views/orders/show.phtml
+++ b/app/views/orders/show.phtml
@@ -1,7 +1,13 @@
 <?php
+use App\Models\Tag;
+
 $user = $this->current_user;
 $client = $order->client();
 $courier = $order->courier();
+$tags = $order->tags()->get();
+$canManageTags = $order->canManageTagsBy($user);
+$attachedTagIds = array_map(fn($tag) => (int) $tag->id, $tags);
+$availableTags = array_filter(Tag::orderedByName(), fn($tag) => !in_array((int) $tag->id, $attachedTagIds, true));
 ?>
 
 <section class="delivery-hero mb-3">
@@ -67,6 +73,59 @@ $courier = $order->courier();
             <div class="fw-semibold"><?= $order->created_at ? date('d/m/Y H:i', strtotime($order->created_at)) : '-' ?></div>
         </div>
     </div>
+</section>
+
+<section class="admin-panel mb-3">
+    <div class="section-toolbar mb-3">
+        <div>
+            <div class="profile-label">Relacao N:N</div>
+            <h2 class="h5 mb-0">Etiquetas</h2>
+        </div>
+        <span class="badge text-bg-light"><?= count($tags) ?> etiqueta<?= count($tags) === 1 ? '' : 's' ?></span>
+    </div>
+
+    <?php if (empty($tags)) : ?>
+        <div class="empty-state">
+            <i class="bi bi-tags fs-3 text-muted"></i>
+            <p class="mb-0 text-muted">Nenhuma etiqueta vinculada.</p>
+        </div>
+    <?php else : ?>
+        <div class="d-flex flex-wrap gap-2 mb-3">
+            <?php foreach ($tags as $tag) : ?>
+            <span class="badge <?= $tag->badgeClass() ?> d-inline-flex align-items-center gap-2">
+                <i class="bi bi-tag"></i> <?= htmlspecialchars($tag->name) ?>
+                <?php if ($canManageTags) : ?>
+                <form action="<?= route('order_tags.destroy', ['id' => $order->id, 'tag_id' => $tag->id]) ?>" method="POST" onsubmit="return confirm('Remover esta etiqueta do pedido?')">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <button class="btn btn-sm btn-link p-0 text-reset" type="submit" title="Remover etiqueta" aria-label="Remover etiqueta">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </form>
+                <?php endif; ?>
+            </span>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($canManageTags) : ?>
+        <?php if (empty($availableTags)) : ?>
+        <p class="text-muted mb-0">Todas as etiquetas disponiveis ja estao vinculadas.</p>
+        <?php else : ?>
+        <form class="d-flex flex-wrap gap-2 align-items-end" action="<?= route('order_tags.create', ['id' => $order->id]) ?>" method="POST">
+            <div>
+                <label class="form-label" for="tag-select">Vincular etiqueta</label>
+                <select id="tag-select" class="form-select" name="tag_id" required>
+                    <?php foreach ($availableTags as $tag) : ?>
+                    <option value="<?= $tag->id ?>"><?= htmlspecialchars($tag->name) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <button class="btn btn-success" type="submit">
+                <i class="bi bi-plus-lg"></i> Adicionar
+            </button>
+        </form>
+        <?php endif; ?>
+    <?php endif; ?>
 </section>
 
 <section class="action-bar">

--- a/app/views/tags/index.phtml
+++ b/app/views/tags/index.phtml
@@ -1,0 +1,99 @@
+<?php
+use App\Models\Tag;
+
+$user = $this->current_user;
+?>
+
+<section class="delivery-hero mb-3">
+    <div class="delivery-hero-content">
+        <span class="status-chip mb-3">
+            <i class="bi bi-tags"></i> Etiquetas
+        </span>
+        <h1 class="fw-bold mb-2">Gerenciar etiquetas</h1>
+        <p class="mb-0">Etiquetas classificam os pedidos em uma relacao N:N. Cada pedido pode ter varias etiquetas e cada etiqueta pode estar em varios pedidos.</p>
+    </div>
+    <img class="delivery-hero-mobilete" src="/assets/images/mobilete.svg" alt="Mobilete em entrega">
+</section>
+
+<?php if ($user->isAdmin()) : ?>
+<section class="admin-panel mb-3">
+    <div class="section-toolbar mb-3">
+        <div>
+            <div class="profile-label">Nova etiqueta</div>
+            <h2 class="h5 mb-0">Cadastrar</h2>
+        </div>
+    </div>
+    <form class="row g-2 align-items-end" action="<?= route('tags.create') ?>" method="POST">
+        <div class="col-12 col-md-6">
+            <label class="form-label" for="tag-name">Nome</label>
+            <input id="tag-name" class="form-control" type="text" name="tag[name]" placeholder="Ex: Urgente" required>
+        </div>
+        <div class="col-12 col-md-4">
+            <label class="form-label" for="tag-color">Cor</label>
+            <select id="tag-color" class="form-select" name="tag[color]">
+                <?php foreach (Tag::colors() as $color) : ?>
+                <option value="<?= $color ?>"><?= ucfirst($color) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col-12 col-md-2">
+            <button class="btn btn-success w-100" type="submit">
+                <i class="bi bi-plus-lg"></i> Criar
+            </button>
+        </div>
+    </form>
+</section>
+<?php endif; ?>
+
+<section class="admin-panel">
+    <div class="section-toolbar mb-3">
+        <div>
+            <div class="profile-label">Catalogo</div>
+            <h2 class="h5 mb-0">Etiquetas cadastradas</h2>
+        </div>
+        <span class="badge text-bg-light"><?= count($tags) ?> etiqueta<?= count($tags) === 1 ? '' : 's' ?></span>
+    </div>
+
+    <?php if (empty($tags)) : ?>
+        <div class="empty-state">
+            <i class="bi bi-tags fs-3 text-muted"></i>
+            <p class="mb-0 text-muted">Nenhuma etiqueta cadastrada.</p>
+        </div>
+    <?php else : ?>
+        <div class="table-responsive">
+            <table class="table align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th>Etiqueta</th>
+                        <th>Pedidos vinculados</th>
+                        <?php if ($user->isAdmin()) : ?>
+                        <th class="text-end">Acoes</th>
+                        <?php endif; ?>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($tags as $tag) : ?>
+                    <tr>
+                        <td>
+                            <span class="badge <?= $tag->badgeClass() ?>">
+                                <i class="bi bi-tag"></i> <?= htmlspecialchars($tag->name) ?>
+                            </span>
+                        </td>
+                        <td><?= $tag->orders()->count() ?></td>
+                        <?php if ($user->isAdmin()) : ?>
+                        <td class="text-end">
+                            <form action="<?= route('tags.destroy', ['id' => $tag->id]) ?>" method="POST" onsubmit="return confirm('Remover esta etiqueta e todos os seus vinculos?')">
+                                <input type="hidden" name="_method" value="DELETE">
+                                <button class="btn btn-sm btn-outline-danger" type="submit" title="Remover etiqueta" aria-label="Remover etiqueta">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </form>
+                        </td>
+                        <?php endif; ?>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+</section>

--- a/config/routes.php
+++ b/config/routes.php
@@ -4,6 +4,7 @@ use App\Controllers\AuthenticationsController;
 use App\Controllers\AdminController;
 use App\Controllers\HomeController;
 use App\Controllers\OrdersController;
+use App\Controllers\TagsController;
 use Core\Router\Route;
 
 Route::get('/login', [AuthenticationsController::class, 'new'])->name('users.login');
@@ -26,6 +27,12 @@ Route::middleware('auth')->group(function () {
     Route::delete('/orders/{id}', [OrdersController::class, 'destroy'])->name('orders.destroy');
     Route::post('/orders/{id}/accept', [OrdersController::class, 'accept'])->name('orders.accept');
     Route::post('/orders/{id}/refuse', [OrdersController::class, 'refuse'])->name('orders.refuse');
+    Route::post('/orders/{id}/tags', [OrdersController::class, 'attachTag'])->name('order_tags.create');
+    Route::delete('/orders/{id}/tags/{tag_id}', [OrdersController::class, 'detachTag'])->name('order_tags.destroy');
+
+    Route::get('/tags', [TagsController::class, 'index'])->name('tags.index');
+    Route::post('/tags', [TagsController::class, 'create'])->name('tags.create');
+    Route::delete('/tags/{id}', [TagsController::class, 'destroy'])->name('tags.destroy');
 });
 
 Route::middleware('admin')->group(function () {

--- a/core/Database/ActiveRecord/BelongsToMany.php
+++ b/core/Database/ActiveRecord/BelongsToMany.php
@@ -56,6 +56,52 @@ class BelongsToMany
         return $models;
     }
 
+    public function attach(int $id): void
+    {
+        $sql = <<<SQL
+            INSERT INTO {$this->pivot_table} ({$this->from_foreign_key}, {$this->to_foreign_key})
+            VALUES (:from_id, :to_id);
+        SQL;
+
+        $pdo = Database::getDatabaseConn();
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindValue(':from_id', $this->model->id);
+        $stmt->bindValue(':to_id', $id);
+        $stmt->execute();
+    }
+
+    public function detach(int $id): void
+    {
+        $sql = <<<SQL
+            DELETE FROM {$this->pivot_table}
+            WHERE {$this->from_foreign_key} = :from_id AND {$this->to_foreign_key} = :to_id;
+        SQL;
+
+        $pdo = Database::getDatabaseConn();
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindValue(':from_id', $this->model->id);
+        $stmt->bindValue(':to_id', $id);
+        $stmt->execute();
+    }
+
+    public function exists(int $id): bool
+    {
+        $sql = <<<SQL
+            SELECT 1
+            FROM {$this->pivot_table}
+            WHERE {$this->from_foreign_key} = :from_id AND {$this->to_foreign_key} = :to_id
+            LIMIT 1;
+        SQL;
+
+        $pdo = Database::getDatabaseConn();
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindValue(':from_id', $this->model->id);
+        $stmt->bindValue(':to_id', $id);
+        $stmt->execute();
+
+        return $stmt->fetchColumn() !== false;
+    }
+
     public function count(): int
     {
         $fromTable = $this->model::table();

--- a/database/Populate/populate.php
+++ b/database/Populate/populate.php
@@ -11,6 +11,12 @@ $pdo = Database::getDatabaseConn();
 $senha = password_hash('password123', PASSWORD_DEFAULT);
 $adminSenha = password_hash('admin123', PASSWORD_DEFAULT);
 
+if ($pdo->query("SHOW TABLES LIKE 'order_tags'")->fetchColumn()) {
+    $pdo->exec("DELETE FROM order_tags");
+}
+if ($pdo->query("SHOW TABLES LIKE 'tags'")->fetchColumn()) {
+    $pdo->exec("DELETE FROM tags");
+}
 if ($pdo->query("SHOW TABLES LIKE 'orders'")->fetchColumn()) {
     $pdo->exec("DELETE FROM orders");
 }
@@ -35,6 +41,26 @@ $pdo->exec("INSERT INTO orders (client_id, courier_id, pickup_address, delivery_
     ($joaoId, null, 'Rua das Palmeiras, 120 - Centro', 'Avenida Brasil, 900 - Vila Nova', 'pequeno', 0, 12.00, 'pendente', 'pix', 11.20, 'ZP1001'),
     ($joaoId, $leonardoId, 'Mercado Municipal - Box 14', 'Rua Sete de Setembro, 45 - Centro', 'medio', 1, 8.00, 'aceito', 'cartao', 20.80, 'ZP1002'),
     ($adminId, $williamId, 'Rua Projetada, 30 - Jardim Sul', 'Condominio Primavera, Bloco B', 'grande', 0, 15.00, 'em rota', 'dinheiro', 21.50, 'ZP1003')
+");
+
+$pdo->exec("INSERT INTO tags (name, color) VALUES
+    ('Urgente', 'danger'),
+    ('Fragil', 'warning'),
+    ('Refrigerado', 'info'),
+    ('Volumoso', 'dark')
+");
+
+$urgenteId = $pdo->query("SELECT id FROM tags WHERE name = 'Urgente'")->fetchColumn();
+$fragilId = $pdo->query("SELECT id FROM tags WHERE name = 'Fragil'")->fetchColumn();
+$refrigeradoId = $pdo->query("SELECT id FROM tags WHERE name = 'Refrigerado'")->fetchColumn();
+
+$orderIds = $pdo->query("SELECT id FROM orders ORDER BY id")->fetchAll(PDO::FETCH_COLUMN);
+
+$pdo->exec("INSERT INTO order_tags (order_id, tag_id) VALUES
+    ({$orderIds[0]}, $urgenteId),
+    ({$orderIds[1]}, $fragilId),
+    ({$orderIds[1]}, $refrigeradoId),
+    ({$orderIds[2]}, $urgenteId)
 ");
 
 echo "Banco populado!\n";

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,5 +1,7 @@
 SET foreign_key_checks = 0;
 
+DROP TABLE IF EXISTS order_tags;
+DROP TABLE IF EXISTS tags;
 DROP TABLE IF EXISTS orders;
 DROP TABLE IF EXISTS notifications;
 DROP TABLE IF EXISTS users;
@@ -42,6 +44,22 @@ CREATE TABLE notifications (
     message VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_notifications_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(40) NOT NULL,
+    color ENUM('secondary', 'primary', 'success', 'danger', 'warning', 'info', 'dark') NOT NULL DEFAULT 'secondary',
+    UNIQUE KEY uq_tags_name (name)
+) ENGINE=InnoDB;
+
+CREATE TABLE order_tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    UNIQUE KEY uq_order_tags (order_id, tag_id),
+    CONSTRAINT fk_order_tags_order FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
+    CONSTRAINT fk_order_tags_tag FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 SET foreign_key_checks = 1;

--- a/tests/Acceptance/Tags/OrderTagsCest.php
+++ b/tests/Acceptance/Tags/OrderTagsCest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Acceptance\Tags;
+
+use App\Models\Order;
+use App\Models\Tag;
+use App\Models\User;
+use Tests\Acceptance\BaseAcceptanceCest;
+use Tests\Support\AcceptanceTester;
+
+class OrderTagsCest extends BaseAcceptanceCest
+{
+    private function makeClient(): User
+    {
+        $user = new User([
+            'name'                  => 'Cliente Teste',
+            'email'                 => 'cliente@example.com',
+            'cpf'                   => '52998224725',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_CLIENT,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeOrder(User $client): Order
+    {
+        $order = new Order([
+            'client_id'         => $client->id,
+            'pickup_address'    => 'Rua de Coleta, 123',
+            'delivery_address'  => 'Rua de Entrega, 456',
+            'distance_km'       => '1.00',
+            'confirmation_code' => 'ABC123',
+        ]);
+        $order->save();
+        return $order;
+    }
+
+    private function makeTag(string $name = 'Urgente'): Tag
+    {
+        $tag = new Tag(['name' => $name, 'color' => Tag::COLOR_DANGER]);
+        $tag->save();
+        return $tag;
+    }
+
+    // 1.1 - Registro da relação
+    public function attachesTagToOrderSuccessfully(AcceptanceTester $page): void
+    {
+        $client = $this->makeClient();
+        $order = $this->makeOrder($client);
+        $this->makeTag('Urgente');
+        $page->login($client->email, '123456');
+
+        $page->amOnPage('/orders/' . $order->id);
+        $page->selectOption('tag_id', 'Urgente');
+        $page->click('Adicionar');
+
+        $page->see('Etiqueta vinculada ao pedido.');
+        $page->see('Urgente');
+    }
+
+    // 1.2 - Visualização da relação
+    public function viewsOrderTags(AcceptanceTester $page): void
+    {
+        $client = $this->makeClient();
+        $order = $this->makeOrder($client);
+        $tag = $this->makeTag('Refrigerado');
+        $order->tags()->attach((int) $tag->id);
+        $page->login($client->email, '123456');
+
+        $page->amOnPage('/orders/' . $order->id);
+
+        $page->see('Etiquetas');
+        $page->see('Refrigerado');
+    }
+
+    // 1.3 - Remoção da relação
+    public function detachesTagFromOrder(AcceptanceTester $page): void
+    {
+        $client = $this->makeClient();
+        $order = $this->makeOrder($client);
+        $tag = $this->makeTag('Fragil');
+        $order->tags()->attach((int) $tag->id);
+        $page->login($client->email, '123456');
+
+        $page->amOnPage('/orders/' . $order->id);
+        $page->click("button[title='Remover etiqueta']");
+        $page->acceptPopup();
+
+        $page->see('Etiqueta removida do pedido.');
+    }
+}

--- a/tests/Acceptance/Tags/TagsAccessCest.php
+++ b/tests/Acceptance/Tags/TagsAccessCest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Acceptance\Tags;
+
+use Tests\Acceptance\BaseAcceptanceCest;
+use Tests\Support\AcceptanceTester;
+
+class TagsAccessCest extends BaseAcceptanceCest
+{
+    // 3.1 - Rotas autenticadas não devem ser acessíveis por usuários não autenticados
+    public function tagsRouteRedirectsGuestToLogin(AcceptanceTester $page): void
+    {
+        $page->amOnPage('/tags');
+        $page->seeInCurrentUrl('/login');
+    }
+}

--- a/tests/Acceptance/Tags/TagsCest.php
+++ b/tests/Acceptance/Tags/TagsCest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Acceptance\Tags;
+
+use App\Models\Order;
+use App\Models\Tag;
+use App\Models\User;
+use Tests\Acceptance\BaseAcceptanceCest;
+use Tests\Support\AcceptanceTester;
+
+class TagsCest extends BaseAcceptanceCest
+{
+    private function makeAdmin(): User
+    {
+        $user = new User([
+            'name'                  => 'Admin Teste',
+            'email'                 => 'admin@example.com',
+            'cpf'                   => '39053344705',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_CLIENT,
+            'is_admin'              => 1,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeOrderFor(User $client): Order
+    {
+        $order = new Order([
+            'client_id'         => $client->id,
+            'pickup_address'    => 'Rua de Coleta, 123',
+            'delivery_address'  => 'Rua de Entrega, 456',
+            'distance_km'       => '1.00',
+            'confirmation_code' => 'ABC123',
+        ]);
+        $order->save();
+        return $order;
+    }
+
+    // 1 - Registro do recurso
+    public function adminCreatesTag(AcceptanceTester $page): void
+    {
+        $admin = $this->makeAdmin();
+        $page->login($admin->email, '123456');
+
+        $page->amOnPage('/tags');
+        $page->fillField('tag[name]', 'Prioritario');
+        $page->click('Criar');
+
+        $page->see('Etiqueta criada com sucesso.');
+        $page->see('Prioritario');
+    }
+
+    // 4 - Remover registros com dependências
+    public function adminRemovesTagWithDependencies(AcceptanceTester $page): void
+    {
+        $admin = $this->makeAdmin();
+        $order = $this->makeOrderFor($admin);
+        $tag = new Tag(['name' => 'Urgente', 'color' => Tag::COLOR_DANGER]);
+        $tag->save();
+        $order->tags()->attach((int) $tag->id);
+
+        $page->login($admin->email, '123456');
+        $page->amOnPage('/tags');
+        $page->click("button[title='Remover etiqueta']");
+        $page->acceptPopup();
+
+        $page->see('Etiqueta removida. Os vinculos com os pedidos tambem foram apagados.');
+    }
+}

--- a/tests/Unit/Models/TagTest.php
+++ b/tests/Unit/Models/TagTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Order;
+use App\Models\Tag;
+use App\Models\User;
+use PDOException;
+use Tests\TestCase;
+
+class TagTest extends TestCase
+{
+    private function makeClient(): User
+    {
+        $user = new User([
+            'name'                  => 'Cliente Teste',
+            'email'                 => 'cliente@example.com',
+            'cpf'                   => '52998224725',
+            'password'              => '123456',
+            'password_confirmation' => '123456',
+            'user_type'             => User::USER_TYPE_CLIENT,
+        ]);
+        $user->save();
+        return $user;
+    }
+
+    private function makeOrder(User $client): Order
+    {
+        $order = new Order([
+            'client_id'        => $client->id,
+            'pickup_address'   => 'Rua de Coleta, 123',
+            'delivery_address' => 'Rua de Entrega, 456',
+            'distance_km'      => '1.00',
+        ]);
+        $order->save();
+        return $order;
+    }
+
+    private function makeTag(array $overrides = []): Tag
+    {
+        $tag = new Tag(array_merge([
+            'name'  => 'Urgente',
+            'color' => Tag::COLOR_DANGER,
+        ], $overrides));
+        $tag->save();
+        return $tag;
+    }
+
+    // 3.1 - validates()
+
+    public function testSaveFailsWithoutName(): void
+    {
+        $tag = new Tag();
+
+        $this->assertFalse($tag->save());
+        $this->assertNotEmpty($tag->errors('name'));
+    }
+
+    public function testSaveFailsWithDuplicateName(): void
+    {
+        $this->makeTag(['name' => 'Urgente']);
+        $duplicate = new Tag(['name' => 'Urgente']);
+
+        $this->assertFalse($duplicate->save());
+        $this->assertNotEmpty($duplicate->errors('name'));
+    }
+
+    public function testSaveFailsWithInvalidColor(): void
+    {
+        $tag = new Tag(['name' => 'Especial', 'color' => 'roxo']);
+
+        $this->assertFalse($tag->save());
+        $this->assertNotEmpty($tag->errors('color'));
+    }
+
+    public function testSavesValidTagWithDefaultColor(): void
+    {
+        $tag = new Tag(['name' => 'Comum']);
+
+        $this->assertTrue($tag->save());
+        $this->assertSame(Tag::COLOR_SECONDARY, $tag->color);
+    }
+
+    public function testBadgeClassReflectsColor(): void
+    {
+        $tag = $this->makeTag(['color' => Tag::COLOR_INFO]);
+
+        $this->assertSame('text-bg-info', $tag->badgeClass());
+    }
+
+    public function testOrderedByNameSortsCaseInsensitively(): void
+    {
+        $this->makeTag(['name' => 'banana']);
+        $this->makeTag(['name' => 'Abacaxi']);
+        $this->makeTag(['name' => 'cereja']);
+
+        $names = array_map(fn(Tag $tag) => $tag->name, Tag::orderedByName());
+
+        $this->assertSame(['Abacaxi', 'banana', 'cereja'], $names);
+    }
+
+    // 2.1 - BelongsToMany (relacao N:N)
+
+    public function testAttachCreatesRelation(): void
+    {
+        $order = $this->makeOrder($this->makeClient());
+        $tag = $this->makeTag();
+
+        $order->tags()->attach((int) $tag->id);
+
+        $this->assertSame(1, $order->tags()->count());
+        $this->assertSame((int) $tag->id, (int) $order->tags()->get()[0]->id);
+    }
+
+    public function testExistsReflectsRelation(): void
+    {
+        $order = $this->makeOrder($this->makeClient());
+        $tag = $this->makeTag();
+
+        $this->assertFalse($order->tags()->exists((int) $tag->id));
+
+        $order->tags()->attach((int) $tag->id);
+
+        $this->assertTrue($order->tags()->exists((int) $tag->id));
+    }
+
+    public function testDetachRemovesRelation(): void
+    {
+        $order = $this->makeOrder($this->makeClient());
+        $tag = $this->makeTag();
+        $order->tags()->attach((int) $tag->id);
+
+        $order->tags()->detach((int) $tag->id);
+
+        $this->assertSame(0, $order->tags()->count());
+        $this->assertEmpty($order->tags()->get());
+    }
+
+    public function testUniqueIndexPreventsDuplicateRelation(): void
+    {
+        $order = $this->makeOrder($this->makeClient());
+        $tag = $this->makeTag();
+        $order->tags()->attach((int) $tag->id);
+
+        $this->expectException(PDOException::class);
+
+        $order->tags()->attach((int) $tag->id);
+    }
+
+    public function testTagOrdersReturnsRelatedOrders(): void
+    {
+        $client = $this->makeClient();
+        $order = $this->makeOrder($client);
+        $tag = $this->makeTag();
+        $order->tags()->attach((int) $tag->id);
+
+        $this->assertSame(1, $tag->orders()->count());
+        $this->assertSame((int) $order->id, (int) $tag->orders()->get()[0]->id);
+    }
+
+    public function testDestroyingTagCascadesRelations(): void
+    {
+        $order = $this->makeOrder($this->makeClient());
+        $tag = $this->makeTag();
+        $order->tags()->attach((int) $tag->id);
+
+        $tag->destroy();
+
+        $this->assertSame(0, $order->tags()->count());
+    }
+}


### PR DESCRIPTION
Implementa o relacionamento muitos-para-muitos (NxN) entre pedidos e etiquetas usando o BelongsToMany do framework.

- core: metodos attach, detach e exists em BelongsToMany
- model Tag e tabelas tags e order_tags (indice unico em order_id+tag_id)
- relacao Order::tags() e permissao canManageTagsBy
- vinculo/visualizacao/remocao de etiquetas na pagina do pedido
- gerenciamento de etiquetas (cadastro e remocao com dependencias)
- seed de etiquetas no populate
- testes unitarios (model e BelongsToMany) e de aceitacao/acesso